### PR TITLE
feat: fix header position

### DIFF
--- a/src/app/components/hero.tsx
+++ b/src/app/components/hero.tsx
@@ -3,7 +3,7 @@ import { ArrowRight } from 'lucide-react'
 
 export default function Hero() {
 	return (
-		<div className="h-[calc(100vh-80px)] w-screen flex flex-col justify-center items-center">
+		<div className="h-screen w-screen flex flex-col justify-center items-center">
 			<h1 className="text-6xl font-bold m-32">
 				Lyst på noe for deg selv?
 			</h1>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -5,7 +5,7 @@ export default async function Header() {
 	//const navItems = await fetch('')
 
 	return (
-		<header className="p-4 min-h-[80px] backdrop-blur-sm top-0 z-10 sticky w-full bg-background/80 border-b border-border flex justify-start items-center">
+		<header className="p-4 min-h-[80px] backdrop-blur-sm top-0 z-10 fixed w-full bg-background/80 border-b border-border flex justify-start items-center">
 			<_Link href="/" className="mr-16">
 				<Image
 					src="/tihlde.svg"


### PR DESCRIPTION
This qol update does the following:

- Changes header from sticky to fixed
- Makes the content of the home page h-screen instead of h-screen - header height