### PR TITLE
Fixed date parsing and population

### DIFF
--- a/src/app/booking/components/ReservationForm.tsx
+++ b/src/app/booking/components/ReservationForm.tsx
@@ -45,6 +45,7 @@ const ReservationForm = ({ items, groups, user }: EventFormType) => {
         return parse(date, 'PPP HH:mm:ss', new Date());
     };
 
+
     const searchParams = useSearchParams();
     const from = searchParams.get('from');
     const to = searchParams.get('to');
@@ -174,8 +175,8 @@ const ReservationForm = ({ items, groups, user }: EventFormType) => {
             <EventFormFields
                 initialData={{
                     item: defaultItem ?? '',
-                    from: new Date(from ?? ''),
-                    to: new Date(to ?? ''),
+                    from: parseDate(from ?? ''),
+                    to: parseDate(to ?? ''),
                 }}
                 items={items}
                 groups={formGroups}

--- a/src/app/booking/components/ReservationFormFields.tsx
+++ b/src/app/booking/components/ReservationFormFields.tsx
@@ -44,8 +44,8 @@ const ReservationFormFields = ({ initialData, items, groups, groupChangeCallback
         resolver: zodResolver(formSchema),
         shouldUnregister: false,
         defaultValues: {
-            item: initialData?.item,
             application_on_behalf: "0",
+            ...initialData
         }
     })
 


### PR DESCRIPTION
Fixed the date-time parsing and population of date-time fields in the booking form:

![image](https://github.com/TIHLDE/kontresv2/assets/33499052/c27266d6-c085-4e6e-89a6-842145a696d5)
As shown in the image, the query params and the date-time fields now match up.