### PR TITLE
Ref/qol feedback

### DIFF
--- a/src/app/[type]/page.tsx
+++ b/src/app/[type]/page.tsx
@@ -1,8 +1,6 @@
 import Calendar from '../../components/ui/calendar/calendar';
-import {
-    getBookableItem,
-    getReservations,
-} from '../../utils/apis/reservations';
+import { getBookableItem, getReservations } from '../../utils/apis/reservations';
+
 
 interface PageProps {
     params: {
@@ -13,9 +11,10 @@ export default async function Page({ params: { type } }: PageProps) {
     let reservationRequest = await getReservations();
 
     let item = await getBookableItem(type);
-    reservationRequest = reservationRequest?.filter(
-        (booking) => type === booking.bookable_item_detail.id,
-    ) ?? [];
+    reservationRequest =
+        reservationRequest?.filter(
+            (booking) => type === booking?.bookable_item_detail?.id,
+        ) ?? [];
     return (
         <div className="md:pt-20">
             <Calendar

--- a/src/app/admin/components/ReservationTable.tsx
+++ b/src/app/admin/components/ReservationTable.tsx
@@ -20,6 +20,7 @@ const ReservationTable = ({ data }: { data: DetailedReservation[] }) => {
             search={true}
             columns={reservationColumns}
             data={data}
+            filterProperty='author_detail'
             rowClickCallback={rowClickCallback}
         />
     );

--- a/src/app/admin/components/ReservationTable.tsx
+++ b/src/app/admin/components/ReservationTable.tsx
@@ -3,6 +3,8 @@
 import { getReservations } from '@/utils/apis/reservations';
 import { DetailedReservation } from '@/utils/apis/types';
 
+
+
 import { DataTable } from './data-table';
 import { reservationColumns } from './reservationColumns';
 import { useRouter } from 'next/navigation';
@@ -14,15 +16,44 @@ const ReservationTable = ({ data }: { data: DetailedReservation[] }) => {
         router.push(`/reservasjon/${data.id}/`);
     };
 
+    const rejectedReservations = data.filter(
+        (reservation) => reservation.state === 'CANCELLED',
+    );
+
+    const otherReservations = data.filter(
+        (reservation) => reservation.state !== 'CANCELLED',
+    );
+
     return (
-        <DataTable
-            searchPlaceholder={'Søk etter brukere...'}
-            search={true}
-            columns={reservationColumns}
-            data={data}
-            filterProperty='author_detail'
-            rowClickCallback={rowClickCallback}
-        />
+        <div className="flex flex-col gap-5">
+            <div className="mt-10">
+                <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
+                    Godkjente og pågående søknader
+                </h2>
+                <DataTable
+                    searchPlaceholder={'Søk etter brukere...'}
+                    search={true}
+                    columns={reservationColumns}
+                    data={otherReservations}
+                    filterProperty="author_detail"
+                    rowClickCallback={rowClickCallback}
+                />
+            </div>
+
+            <div>
+                <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
+                    Avslåtte søknader
+                </h2>
+                <DataTable
+                    searchPlaceholder={'Søk etter brukere...'}
+                    search={true}
+                    columns={reservationColumns}
+                    data={rejectedReservations}
+                    filterProperty="author_detail"
+                    rowClickCallback={rowClickCallback}
+                />
+            </div>
+        </div>
     );
 };
 

--- a/src/app/admin/components/data-table.tsx
+++ b/src/app/admin/components/data-table.tsx
@@ -111,6 +111,7 @@ export function DataTable<TData, TValue>({
                                     onClick={() => {
                                         rowClickCallback?.(row.original);
                                     }}
+                                    className={`${rowClickCallback ? 'cursor-pointer' : ''}`}
                                 >
                                     {row.getVisibleCells().map((cell) => (
                                         <TableCell key={cell.id}>

--- a/src/app/booking/components/ReservationForm.tsx
+++ b/src/app/booking/components/ReservationForm.tsx
@@ -2,29 +2,26 @@
 
 import { User } from '@/types/User';
 
-import {
-    AlertDialogAction,
-    AlertDialogCancel,
-    AutoAlertDialog,
-} from '@/components/ui/alert-dialog';
+
+
+import { AlertDialogAction, AlertDialogCancel, AutoAlertDialog } from '@/components/ui/alert-dialog';
 import { Toaster } from '@/components/ui/toaster';
 import { useToast } from '@/components/ui/use-toast';
 
+
+
 import { ErrorType } from '@/utils/apis/fetch';
-import {
-    createReservation,
-    invalidateReservations,
-} from '@/utils/apis/reservations';
+import { createReservation, invalidateReservations } from '@/utils/apis/reservations';
 import { DetailedItem, Membership } from '@/utils/apis/types';
 
+
+
 import ApplicantCard from './ApplicantCard';
-import {
-    ReservationFormFields,
-    ReservationFormValueTypes
-} from '@/app/booking/components/ReservationFormFields';
+import { ReservationFormFields, ReservationFormValueTypes } from '@/app/booking/components/ReservationFormFields';
 import { parse } from 'date-fns';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRef, useState } from 'react';
+
 
 type EventFormType = {
     items: DetailedItem[];
@@ -111,7 +108,7 @@ const ReservationForm = ({ items, groups, user }: EventFormType) => {
             start_time: values?.from.toISOString() as string,
             end_time: values?.to.toISOString() as string,
             group: group as string,
-            alcohol_agreement: values?.alcohol_agreement,
+            serves_alcohol: values?.serves_alcohol,
             sober_watch: values?.sober_watch_id,
         })
             .then((res) => {

--- a/src/app/booking/components/ReservationFormFields.tsx
+++ b/src/app/booking/components/ReservationFormFields.tsx
@@ -1,22 +1,16 @@
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { DateTimePicker } from '@/components/ui/date-time-picker';
-import {
-    Form,
-    FormControl,
-    FormDescription,
-    FormField,
-    FormItem,
-    FormLabel,
-} from '@/components/ui/form';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { LoadingSpinner } from '@/components/ui/loadingspinner';
-import AutoSelect, {
-    SelectGroupType,
-    SelectOptionType,
-} from '@/components/ui/select';
+import AutoSelect, { SelectGroupType, SelectOptionType } from '@/components/ui/select';
+
+
 
 import { DetailedItem } from '@/utils/apis/types';
+
+
 
 import UserAutocomplete from './UserAutocomplete';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -24,6 +18,7 @@ import Link from 'next/link';
 import { Dispatch, SetStateAction } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
+
 
 const formSchema = z.object({
     from: z.date(),
@@ -37,7 +32,7 @@ const formSchema = z.object({
     description: z.string().min(10, {
         message: 'Beskrivelsen må være mer enn 10 tegn lang',
     }),
-    alcohol_agreement: z.boolean().optional(),
+    serves_alcohol: z.boolean().optional(),
     sober_watch_id: z.string().optional(),
 });
 
@@ -202,7 +197,7 @@ const ReservationFormFields = ({
                     <>
                         <FormField
                             control={form.control}
-                            name="alcohol_agreement"
+                            name="serves_alcohol"
                             render={({ field: { value, ...rest } }) => (
                                 <FormItem className="flex items-center space-x-2">
                                     <FormControl>
@@ -211,7 +206,7 @@ const ReservationFormFields = ({
                                             checked={value}
                                             onCheckedChange={(e) =>
                                                 form.setValue(
-                                                    'alcohol_agreement',
+                                                    'serves_alcohol',
                                                     Boolean(e.valueOf()),
                                                     {
                                                         shouldDirty: true,
@@ -235,7 +230,7 @@ const ReservationFormFields = ({
                                 </FormItem>
                             )}
                         />
-                        {form.watch('alcohol_agreement') && (
+                        {form.watch('serves_alcohol') && (
                             <FormField
                                 control={form.control}
                                 name="sober_watch_id"

--- a/src/app/components/hero.tsx
+++ b/src/app/components/hero.tsx
@@ -1,5 +1,7 @@
 import { buttonVariants } from '@/components/ui/button';
 
+
+
 import { getItems } from '@/utils/apis/items';
 
 import styles from './welcometitle.module.css';
@@ -9,24 +11,14 @@ import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 
 export default async function Hero() {
-    //TODO: burde kanskje håndtere fetch errors actionen istedet for hver enkelt call?
-    let items;
-    try {
-        items = await getItems();
-    } catch (e) {
-        console.error(e);
-    }
-
-    console.log(items);
-    console.log(items?.find((item) => item.name === 'Kontoret')?.id);
-
     return (
         <div className="h-[100vh] md:mt-[-5rem] w-full flex flex-col justify-center items-center relative overflow-x-hidden">
             <WelcomeTitle />
 
             <div className={`flex flex-col gap-0 ${styles.action}`}>
                 <p className="text-lg md:text-xl md:mt-8 mt-3 md:mb-12 mb-6 text-center text-muted-foreground">
-                    Her kan du som medlem i TIHLDE booke kontoret, <br></br> Soundboks eller annet utstyr.
+                    Her kan du som medlem i TIHLDE booke kontoret, <br></br>{' '}
+                    Soundboks eller annet utstyr.
                 </p>
                 <div className="flex items-center flex-col md:flex-row w-2/3 md:w-fit mx-auto">
                     <Link
@@ -34,26 +26,10 @@ export default async function Hero() {
                             buttonVariants({ variant: 'default' }),
                             'm-2 p-8 text-lg group w-full',
                         )}
-                        href={`/${
-                            items?.find((item) => item.name === 'Kontoret')
-                                ?.id ?? 'booking'
-                        }`}
+                        href={`/booking`}
                     >
-                        Reserver kontoret
-                        <ArrowRight className="mr-2 group-hover:-translate-x-1 transition-transform duration-150 min-w-8" />
-                    </Link>
-                    <Link
-                        className={cn(
-                            buttonVariants({ variant: 'outline' }),
-                            'm-2 p-8 text-lg group w-full',
-                        )}
-                        href={`/${
-                            items?.find((item) => item.name === 'Soundboks')
-                                ?.id ?? 'booking'
-                        }`}
-                    >
-                        Reserver Soundboks
-                        <ArrowRight className="ml-2 group-hover:translate-x-1 transition-transform duration-150 min-w-8" />
+                        Reserver en gjenstand
+                        <ArrowRight className="mr-2 group-hover:translate-x-1 transition-transform duration-150 min-w-8" />
                     </Link>
                 </div>
             </div>

--- a/src/app/components/hero.tsx
+++ b/src/app/components/hero.tsx
@@ -12,7 +12,7 @@ import Link from 'next/link';
 
 export default async function Hero() {
     return (
-        <div className="h-[100vh] md:mt-[-5rem] w-full flex flex-col justify-center items-center relative overflow-x-hidden">
+        <div className="h-[100vh] md:mt-[-5rem] -mt-28 w-full flex flex-col justify-center items-center relative overflow-x-hidden">
             <WelcomeTitle />
 
             <div className={`flex flex-col gap-0 ${styles.action}`}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default async function RootLayout({
                     disableTransitionOnChange
                 >
                     <Header className="lg:flex hidden" />
-                    <div className="md:py-page pt-8 pb-32">
+                    <div className="py-page pb-32">
                         <Toaster />
                         {children}
                     </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,7 +16,7 @@ export default function Page({
 
     return (
         /* This isn't a very elegant solution..? */
-        <div className="max-w-page mx-auto md:h-[calc(100vh_-_theme(padding.page)_*_2)] h-screen flex flex-col justify-center items-center">
+        <div className="max-w-page mx-auto h-screen -mt-24 flex flex-col justify-center items-center">
             <Card className="w-80">
                 <CardHeader>
                     <CardTitle className="text-center">Login</CardTitle>

--- a/src/app/reservasjon/[id]/components/AdminButtons.tsx
+++ b/src/app/reservasjon/[id]/components/AdminButtons.tsx
@@ -137,6 +137,7 @@ const AdminButtons = ({ reservationId }: AdminButtonsProps) => {
         // Delete the reservation
         return deleteReservation(reservationId).catch((err) => {
             informFailure(err.message);
+            throw new Error();
         });
     };
 
@@ -196,12 +197,15 @@ const AdminButtons = ({ reservationId }: AdminButtonsProps) => {
                                 className="bg-destructive text-background"
                                 onClick={() => {
                                     setDeleteLoading(true);
-                                    onDeleteReservation().then(() => {
-                                        setDeleteLoading(false);
-                                        setDeleteOpen(false);
-                                        router.back();
-                                        invalidateReservations();
-                                    });
+                                    onDeleteReservation()
+                                        .then(() => {
+                                            setDeleteOpen(false);
+                                            router.back();
+                                            invalidateReservations();
+                                        })
+                                        .finally(() => {
+                                            setDeleteLoading(false);
+                                        });
                                 }}
                             >
                                 {deleteLoading ? <LoadingSpinner /> : 'Slett'}

--- a/src/app/reservasjon/[id]/components/AdminButtons.tsx
+++ b/src/app/reservasjon/[id]/components/AdminButtons.tsx
@@ -164,7 +164,7 @@ const AdminButtons = ({ reservationId }: AdminButtonsProps) => {
 
                 <DropdownMenu>
                     <DropdownMenuTrigger>
-                        <Button variant="ghost" className="px-2">
+                        <Button variant="outline" className="px-2 md:w-fit w-full">
                             <MoreVertical className="h-4 w-4" />
                         </Button>
                     </DropdownMenuTrigger>

--- a/src/app/reservasjon/[id]/components/AdminButtons.tsx
+++ b/src/app/reservasjon/[id]/components/AdminButtons.tsx
@@ -142,8 +142,7 @@ const AdminButtons = ({ reservationId }: AdminButtonsProps) => {
     };
 
     return (
-        <div className="w-full flex flex-col gap-3 p-5">
-            <div className="w-full flex flex-col md:flex-row gap-3">
+            <div className="w-full flex flex-col md:flex-row gap-3 p-5">
                 <Button
                     ref={acceptRef}
                     className="w-full"
@@ -214,7 +213,6 @@ const AdminButtons = ({ reservationId }: AdminButtonsProps) => {
                     </AlertDialogContent>
                 </AlertDialog>
             </div>
-        </div>
     );
 };
 

--- a/src/app/reservasjon/[id]/components/AdminButtons.tsx
+++ b/src/app/reservasjon/[id]/components/AdminButtons.tsx
@@ -163,7 +163,7 @@ const AdminButtons = ({ reservationId }: AdminButtonsProps) => {
                 </Button>
 
                 <DropdownMenu>
-                    <DropdownMenuTrigger>
+                    <DropdownMenuTrigger asChild>
                         <Button variant="outline" className="px-2 md:w-fit w-full">
                             <MoreVertical className="h-4 w-4" />
                         </Button>

--- a/src/app/reservasjon/[id]/components/AdminButtons.tsx
+++ b/src/app/reservasjon/[id]/components/AdminButtons.tsx
@@ -1,15 +1,34 @@
-"use client"
+'use client';
 
-import { Button } from "@/components/ui/button"
-import { invalidateReservations, setReservationState } from "@/utils/apis/reservations"
-import { useAtom } from "jotai";
-import { StateAtomType, stateAtom } from "./ReservationMeta";
-import { ReservationState } from "@/utils/apis/types";
-import { useRef, useState } from "react";
-import { LoadingSpinner } from "@/components/ui/loadingspinner";
-import { usePop } from "@/utils/animations/buttonPop";
-import { useToast } from "@/components/ui/use-toast";
-import { useShake } from "@/utils/animations/shake";
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { LoadingSpinner } from '@/components/ui/loadingspinner';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
+import { useToast } from '@/components/ui/use-toast';
+
+import { usePop } from '@/utils/animations/buttonPop';
+import { useShake } from '@/utils/animations/shake';
+import {
+    invalidateReservations,
+    setReservationState,
+} from '@/utils/apis/reservations';
+import { ReservationState } from '@/utils/apis/types';
+
+import { StateAtomType, stateAtom } from './ReservationMeta';
+import { useAtom } from 'jotai';
+import { Delete, MoreVertical, Trash } from 'lucide-react';
+import { useRef, useState } from 'react';
 
 interface AdminButtonsProps {
     reservationId: string;
@@ -20,8 +39,8 @@ type Flags<T extends PropertyKey> = Record<T, StateAtomType>;
 const mapObject: Flags<ReservationState> = {
     CONFIRMED: 'Bekreftet',
     PENDING: 'Avventer',
-    CANCELLED: 'Avslått'
-}
+    CANCELLED: 'Avslått',
+};
 
 const AdminButtons = ({ reservationId }: AdminButtonsProps) => {
     const [rejectLoading, setRejectLoading] = useState(false);
@@ -37,68 +56,107 @@ const AdminButtons = ({ reservationId }: AdminButtonsProps) => {
 
     const { toast } = useToast();
 
-
     const informSuccess = () => {
         toast({
-            title: "Vellykket!",
-            description: "Endringene er lagret.",
-        })
-    }
-
-    const informFailure = (detailedErrorMessage: string | undefined = undefined) => {
-        toast({
-            title: "Noe gikk galt.",
-            description: detailedErrorMessage || "En uventet feil oppstod.",
-            variant: "destructive"
+            title: 'Vellykket!',
+            description: 'Endringene er lagret.',
         });
     };
 
+    const informFailure = (
+        detailedErrorMessage: string | undefined = undefined,
+    ) => {
+        toast({
+            title: 'Noe gikk galt.',
+            description: detailedErrorMessage || 'En uventet feil oppstod.',
+            variant: 'destructive',
+        });
+    };
 
     const onReject = () => {
         // Reject the reservation
         setRejectLoading(true);
-        setReservationState(reservationId, 'CANCELLED').then((data) => {
-            setRejectLoading(false);
-            invalidateReservations();
-            informSuccess();
-            pop.run({ ref: rejectRef })
-            setState(mapObject[data.state])
-        }).catch(err => {
-            informFailure();
-            setRejectLoading(false);
-            shake.run({ ref: rejectRef })
-        });
-    }
+        setReservationState(reservationId, 'CANCELLED')
+            .then((data) => {
+                setRejectLoading(false);
+                invalidateReservations();
+                informSuccess();
+                pop.run({ ref: rejectRef });
+                setState(mapObject[data.state]);
+            })
+            .catch((err) => {
+                informFailure();
+                setRejectLoading(false);
+                shake.run({ ref: rejectRef });
+            });
+    };
 
     const onAccept = () => {
         // Accept the reservation
         setAcceptLoading(true);
-        setReservationState(reservationId, 'CONFIRMED').then((data) => {
-            setAcceptLoading(false);
-            invalidateReservations();
-            pop.run({ ref: acceptRef })
-            informSuccess();
-            setState(mapObject[data.state])
-        }).catch(err => {
-            try {
-                const errorObj = JSON.parse(err.message);
-                const detailedErrorMessage = errorObj.response?.non_field_errors[0] || 'An unknown error occurred';
-                informFailure(detailedErrorMessage);
-            } catch (parseError) {
-                console.error("Error parsing the error message:", parseError);
-                informFailure();
-            }
-            setAcceptLoading(false);
-            shake.run({ ref: acceptRef });
-        });
-    }
+        setReservationState(reservationId, 'CONFIRMED')
+            .then((data) => {
+                setAcceptLoading(false);
+                invalidateReservations();
+                pop.run({ ref: acceptRef });
+                informSuccess();
+                setState(mapObject[data.state]);
+            })
+            .catch((err) => {
+                try {
+                    const errorObj = JSON.parse(err.message);
+                    const detailedErrorMessage =
+                        errorObj.response?.non_field_errors[0] ||
+                        'An unknown error occurred';
+                    informFailure(detailedErrorMessage);
+                } catch (parseError) {
+                    console.error(
+                        'Error parsing the error message:',
+                        parseError,
+                    );
+                    informFailure();
+                }
+                setAcceptLoading(false);
+                shake.run({ ref: acceptRef });
+            });
+    };
 
     return (
-        <div className="w-full flex flex-col md:flex-row gap-3 p-5">
-            <Button ref={acceptRef} className="w-full" onClick={onAccept} disabled={acceptLoading || rejectLoading}>{acceptLoading ? <LoadingSpinner /> : 'Godkjenn'}</Button>
-            <Button ref={rejectRef} className="w-full" onClick={onReject} variant={"destructive"} disabled={acceptLoading || rejectLoading}>{rejectLoading ? <LoadingSpinner /> : 'Avslå'}</Button>
+        <div className="w-full flex flex-col gap-3 p-5">
+            <div className="w-full flex flex-col md:flex-row gap-3">
+                <Button
+                    ref={acceptRef}
+                    className="w-full"
+                    onClick={onAccept}
+                    disabled={acceptLoading || rejectLoading}
+                >
+                    {acceptLoading ? <LoadingSpinner /> : 'Godkjenn'}
+                </Button>
+                <Button
+                    ref={rejectRef}
+                    className="w-full"
+                    onClick={onReject}
+                    variant={'destructive'}
+                    disabled={acceptLoading || rejectLoading}
+                >
+                    {rejectLoading ? <LoadingSpinner /> : 'Avslå'}
+                </Button>
+
+                <DropdownMenu>
+                    <DropdownMenuTrigger>
+                        <Button variant="outline">
+                            <MoreVertical className="h-4 w-4" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                        <DropdownMenuLabel>Handlinger</DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem>Slett</DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </div>
         </div>
-    )
-}
+    );
+};
 
 export default AdminButtons;

--- a/src/app/reservasjon/[id]/components/ReservationMeta.tsx
+++ b/src/app/reservasjon/[id]/components/ReservationMeta.tsx
@@ -1,38 +1,49 @@
 "use client";
 
-import { Card } from "@/components/ui/card"
-import { GroupProfilePill, UserProfilePill } from "@/components/ui/profilepill";
-import { User } from "@/types/User";
-import { BaseGroup, ReservationState } from "@/utils/apis/types";
-import { format } from "date-fns"
-import { nb } from "date-fns/locale/nb";
+import { User } from '@/types/User';
+
+import { Card } from '@/components/ui/card';
+import { GroupProfilePill, UserProfilePill } from '@/components/ui/profilepill';
+
+import { BaseGroup, ReservationState } from '@/utils/apis/types';
+
+import { format } from 'date-fns';
+import { nb } from 'date-fns/locale/nb';
 import { atom, useAtom } from 'jotai';
-import { useEffect } from "react";
+import { useEffect } from 'react';
 
 interface ReservationMetaProps {
     from: string;
     to: string;
     user: User;
     group: BaseGroup;
+    soberWatch?: User;
     state: ReservationState;
 }
 
 export const stateMap: { [key in ReservationState]: StateAtomType } = {
-    CANCELLED: "Avslått",
-    CONFIRMED: "Bekreftet",
-    PENDING: "Avventer"
-}
+    CANCELLED: 'Avslått',
+    CONFIRMED: 'Bekreftet',
+    PENDING: 'Avventer',
+};
 
 export type StateAtomType = 'Bekreftet' | 'Avventer' | 'Avslått' | 'Laster';
 export const stateAtom = atom<StateAtomType>('Laster');
 
-const ReservationMeta = ({ from, to, user, group, state }: ReservationMetaProps) => {
+const ReservationMeta = ({
+    from,
+    to,
+    user,
+    group,
+    state,
+    soberWatch,
+}: ReservationMetaProps) => {
+    console.log(soberWatch);
     const [stateText, setStateText] = useAtom(stateAtom);
 
     useEffect(() => {
-        setStateText(stateMap[state])
-    }, [state, setStateText])
-
+        setStateText(stateMap[state]);
+    }, [state, setStateText]);
 
     return (
         <Card>
@@ -55,34 +66,42 @@ const ReservationMeta = ({ from, to, user, group, state }: ReservationMetaProps)
                     </p>
                 </div>
                 <div>
-                    <h2 className="font-semibold text-xl">
-                        Skrevet av
-                    </h2>
+                    <h2 className="font-semibold text-xl">Skrevet av</h2>
                     <UserProfilePill user={user} />
-
                 </div>
-                {
-                    group &&
-                    (
-                        <div>
-                            <h2 className="font-semibold text-xl text-nowrap">
-                                På vegne av
-                            </h2>
-                            <GroupProfilePill className="w-full" group={group} />
-                        </div>
-                    )
-                }
+
+                {group && (
+                    <div>
+                        <h2 className="font-semibold text-xl text-nowrap">
+                            På vegne av
+                        </h2>
+                        <GroupProfilePill className="w-full" group={group} />
+                    </div>
+                )}
+
+                {soberWatch && (
+                    <div>
+                        <h2 className="font-semibold text-xl text-nowrap">
+                            Edruvakt
+                        </h2>
+                        <UserProfilePill className="w-full" user={soberWatch} />
+                    </div>
+                )}
                 <div>
                     <h2 className="font-semibold text-xl text-nowrap">
                         Status
                     </h2>
-                    <span className={`${stateText === "Avventer" && 'text-yellow-500'} 
-                                                ${stateText === "Bekreftet" && 'text-green-500'} 
-                                                ${stateText === "Avslått" && 'text-red-500'}`}>{stateText}</span>
+                    <span
+                        className={`${stateText === 'Avventer' && 'text-yellow-500'} 
+                                                ${stateText === 'Bekreftet' && 'text-green-500'} 
+                                                ${stateText === 'Avslått' && 'text-red-500'}`}
+                    >
+                        {stateText}
+                    </span>
                 </div>
             </div>
         </Card>
-    )
-}
+    );
+};
 
 export default ReservationMeta;

--- a/src/app/reservasjon/[id]/components/ReservationMeta.tsx
+++ b/src/app/reservasjon/[id]/components/ReservationMeta.tsx
@@ -47,6 +47,8 @@ const ReservationMeta = ({
 }: ReservationMetaProps) => {
     const [stateText, setStateText] = useAtom(stateAtom);
 
+    console.log(soberWatch);
+
     useEffect(() => {
         setStateText(stateMap[state]);
     }, [state, setStateText]);

--- a/src/app/reservasjon/[id]/components/ReservationMeta.tsx
+++ b/src/app/reservasjon/[id]/components/ReservationMeta.tsx
@@ -47,8 +47,6 @@ const ReservationMeta = ({
 }: ReservationMetaProps) => {
     const [stateText, setStateText] = useAtom(stateAtom);
 
-    console.log(soberWatch);
-
     useEffect(() => {
         setStateText(stateMap[state]);
     }, [state, setStateText]);

--- a/src/app/reservasjon/[id]/components/ReservationMeta.tsx
+++ b/src/app/reservasjon/[id]/components/ReservationMeta.tsx
@@ -2,15 +2,22 @@
 
 import { User } from '@/types/User';
 
+
+
 import { Card } from '@/components/ui/card';
 import { GroupProfilePill, UserProfilePill } from '@/components/ui/profilepill';
 
+
+
 import { BaseGroup, ReservationState } from '@/utils/apis/types';
+
+
 
 import { format } from 'date-fns';
 import { nb } from 'date-fns/locale/nb';
 import { atom, useAtom } from 'jotai';
 import { useEffect } from 'react';
+
 
 interface ReservationMetaProps {
     from: string;
@@ -38,7 +45,6 @@ const ReservationMeta = ({
     state,
     soberWatch,
 }: ReservationMetaProps) => {
-    console.log(soberWatch);
     const [stateText, setStateText] = useAtom(stateAtom);
 
     useEffect(() => {

--- a/src/app/reservasjon/[id]/components/ReservationMetaWrapper.tsx
+++ b/src/app/reservasjon/[id]/components/ReservationMetaWrapper.tsx
@@ -1,3 +1,5 @@
+import { User } from '@/types/User';
+
 import { getReservation } from '@/utils/apis/reservations';
 import { BaseGroup } from '@/utils/apis/types';
 
@@ -18,6 +20,7 @@ const ReservationMetaWrapper = async ({
             group={reservation.group_detail as BaseGroup}
             state={reservation.state}
             user={reservation.author_detail}
+            soberWatch={reservation.sober_watch}
         />
     );
 };

--- a/src/app/reservasjon/[id]/components/TitleWrapper.tsx
+++ b/src/app/reservasjon/[id]/components/TitleWrapper.tsx
@@ -7,7 +7,7 @@ const TitleWrapper = async ({ params }: { params: { id: string } }) => {
         <h1 className="font-semibold my-3 text-3xl w-fit mx-auto mt-10 text-center">
             Reservasjon av{' '}
             <span className="lowercase">
-                {reservation.bookable_item_detail.name}
+                {reservation?.bookable_item_detail ? reservation?.bookable_item_detail?.name : 'ukjent gjenstand'}
             </span>
         </h1>
     );

--- a/src/app/reservasjon/[id]/page.tsx
+++ b/src/app/reservasjon/[id]/page.tsx
@@ -1,12 +1,12 @@
 import { Card } from '@/components/ui/card';
 
-import { getReservation } from '@/utils/apis/reservations';
-import { BaseGroup, PermissionApp } from '@/utils/apis/types';
+
+
+import { PermissionApp } from '@/utils/apis/types';
 import { checkUserPermissions } from '@/utils/apis/user';
 
 import AdminButtons from './components/AdminButtons';
 import DescriptionWrapper from './components/DescriptionWrapper';
-import ReservationMeta from './components/ReservationMeta';
 import ReservationMetaWrapper from './components/ReservationMetaWrapper';
 import TitleWrapper from './components/TitleWrapper';
 import Image from 'next/image';

--- a/src/components/layout/header/header-buttons-wrapper.tsx
+++ b/src/components/layout/header/header-buttons-wrapper.tsx
@@ -8,8 +8,12 @@ import BookableItems from '../../ui/bookable-items';
 import HeaderLink from '../../ui/header-link';
 import Logo from '../../ui/logo';
 import { UserArea } from '../user-area';
+import { cn } from '@/lib/utils';
 
-const HeaderButtonsWrapper = async () => {
+const HeaderButtonsWrapper = async ({
+    className,
+    ...props
+}: React.HTMLProps<HTMLDivElement>) => {
     let admin = false;
     let items: DetailedItem[] = [];
     let userData;
@@ -23,7 +27,13 @@ const HeaderButtonsWrapper = async () => {
     }
 
     return (
-        <>
+        <div
+            {...props}
+            className={cn(
+                'w-full h-full justify-start items-center flex',
+                className,
+            )}
+        >
             <nav className="flex gap-6 w-full items-center">
                 <HeaderLink href="/" className="mr-16">
                     <Logo />
@@ -39,7 +49,7 @@ const HeaderButtonsWrapper = async () => {
                     admin={admin}
                 />
             ) : undefined}
-        </>
+        </div>
     );
 };
 

--- a/src/components/layout/header/header-wrapper.tsx
+++ b/src/components/layout/header/header-wrapper.tsx
@@ -28,7 +28,7 @@ export default function HeaderWrapper({
     return (
         <header
             className={cn(
-                'p-4 py-1 min-h-[80px] backdrop-blur-sm top-0 transition-all duration-300 fixed w-full bg-background/80 border-border justify-start items-center flex z-50',
+                'p-4 py-1 min-h-[80px] backdrop-blur-sm top-0 transition-all duration-300 fixed w-full bg-background/80 border-border flex items-center z-50',
                 isScrolled ? 'border-b' : '',
                 className,
             )}

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -1,17 +1,16 @@
 import { User } from '@/types/User';
 
-import Logo from '@/components/ui/logo';
 
-import { AdminPermissions, DetailedItem } from '@/utils/apis/types';
-import { checkUserPermissions } from '@/utils/apis/user';
 
-import BookableItems from '../../ui/bookable-items';
-import HeaderLink from '../../ui/header-link';
-import { UserArea } from '../user-area';
+import { DetailedItem } from '@/utils/apis/types';
+
+
+
 import HeaderButtonsWrapper from './header-buttons-wrapper';
 import HeaderSkeleton from './header-skeleton';
 import HeaderWrapper from './header-wrapper';
 import { Suspense } from 'react';
+
 
 interface HeaderProps extends React.HTMLProps<HTMLHeadElement> {
     userData?: User;
@@ -20,10 +19,13 @@ interface HeaderProps extends React.HTMLProps<HTMLHeadElement> {
 
 export default async function Header({ className, ...props }: HeaderProps) {
     return (
-        <HeaderWrapper {...props} className="md:flex hidden">
+        <HeaderWrapper {...props}>
             <Suspense fallback={<HeaderSkeleton />}>
                 <HeaderButtonsWrapper />
             </Suspense>
+            <div className='md:hidden flex'>
+
+            </div>
         </HeaderWrapper>
     );
 }

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -2,13 +2,14 @@ import { User } from '@/types/User';
 
 
 
+import Logo from '@/components/ui/logo';
+
 import { DetailedItem } from '@/utils/apis/types';
-
-
 
 import HeaderButtonsWrapper from './header-buttons-wrapper';
 import HeaderSkeleton from './header-skeleton';
 import HeaderWrapper from './header-wrapper';
+import Link from 'next/link';
 import { Suspense } from 'react';
 
 
@@ -20,11 +21,15 @@ interface HeaderProps extends React.HTMLProps<HTMLHeadElement> {
 export default async function Header({ className, ...props }: HeaderProps) {
     return (
         <HeaderWrapper {...props}>
-            <Suspense fallback={<HeaderSkeleton />}>
-                <HeaderButtonsWrapper />
-            </Suspense>
-            <div className='md:hidden flex'>
-
+            <div className="w-full h-full hidden md:block">
+                <Suspense fallback={<HeaderSkeleton />}>
+                    <HeaderButtonsWrapper />
+                </Suspense>
+            </div>
+            <div className="md:hidden flex place-content-center w-full">
+                <Link href={'/'}>
+                    <Logo />
+                </Link>
             </div>
         </HeaderWrapper>
     );

--- a/src/utils/apis/fetch.ts
+++ b/src/utils/apis/fetch.ts
@@ -29,6 +29,10 @@ export const IFetch = <T extends unknown>({ url, config }: IFetchProps) => {
   })
     .then(async res => {
       if (!res.ok) {
+        if (res.status === 500) {
+          throw new Error('Internal server error');
+        }
+
         const message = await res.json();
         const errorObject: ErrorType = {
           status: res.status,

--- a/src/utils/apis/reservations.ts
+++ b/src/utils/apis/reservations.ts
@@ -88,6 +88,15 @@ export const setReservationState = (uuid: string, state: ReservationState) => {
     });
 }
 
+export const deleteReservation = (uuid: string) => {
+    return IFetch({
+        url: `${baseUrl}/kontres/reservations/${uuid}/`,
+        config: {
+            method: 'DELETE',
+        },
+    });
+}
+
 export const invalidateReservations = () => {
     revalidateTag(validationTags.reservations);
 }

--- a/src/utils/apis/types.ts
+++ b/src/utils/apis/types.ts
@@ -7,7 +7,7 @@ export type DetailedReservation = {
     description: string;
     author_detail: User;
     group_detail: BaseGroup | undefined;
-    alcohol_agreement?: boolean;
+    serves_alcohol?: boolean;
     sober_watch?: string;
 } & BaseModel;
 

--- a/src/utils/apis/types.ts
+++ b/src/utils/apis/types.ts
@@ -8,7 +8,7 @@ export type DetailedReservation = {
     author_detail: User;
     group_detail: BaseGroup | undefined;
     serves_alcohol?: boolean;
-    sober_watch?: string;
+    sober_watch?: User;
 } & BaseModel;
 
 export type ReservationState = 'CONFIRMED' | 'PENDING' | 'CANCELLED';

--- a/src/utils/apis/types.ts
+++ b/src/utils/apis/types.ts
@@ -16,6 +16,7 @@ export type ReservationState = 'CONFIRMED' | 'PENDING' | 'CANCELLED';
 export type PostReservation = {
     bookable_item: string;
     group: string;
+    sober_watch?: string;
 } & Omit<
     DetailedReservation,
     | 'state'
@@ -23,6 +24,7 @@ export type PostReservation = {
     | 'author_detail'
     | 'bookable_item_detail'
     | 'group_detail'
+    | 'sober_watch'
     | keyof BaseModel
 >;
 


### PR DESCRIPTION
This branch fixes some of the pain points from our first round of user testing
Implemented the following features:
- Divided admin page into accepted and ongoing reservation requests, and rejected requests.
- Added a delete button for reservations (this is waiting for a backend implementation to work properly)
- Added a header for mobile which only displays the TIHLDE logo. This can be pressed to navigate to the home screen.
- Fixed some vertical alignment for login and landing pages.
- Added sober watch card on the reservation preview page. It is only shown when a sober watch has been defined.
- Fixed a bug for the admin reservation list where the user could not use the search field

![image](https://github.com/TIHLDE/kontresv2/assets/33499052/d8716e7f-c4fd-400b-98a5-ccb6264bd23f)
![image](https://github.com/TIHLDE/kontresv2/assets/33499052/cfa7482d-01e0-4aaf-ad36-caa5b0e0ae20)
![image](https://github.com/TIHLDE/kontresv2/assets/33499052/bb0d43c0-7f4f-47cb-be26-7636cf0c1824)
