### PR TITLE
docs: client_id genereres av Photon, den kan ikke velges

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,14 +9,37 @@
 # When adding additional environment variables, the schema in "/src/env.js"
 # should be updated accordingly.
 
+# INGEN ANFØRSELSTEGN RUNDT VERDIENE.
+#
+# `deploy.sh` starter containeren med `docker run --env-file .env`, og Docker
+# tolker ikke anførselstegn — de blir en del av verdien. AUTH_URL="https://..."
+# havner da i containeren som "https://..." med anførselstegn og alt, og
+# next-auth svelger URL-parsefeilen og bygger absolutte URL-er fra containerens
+# eget vertsnavn i stedet. Innloggingen sender da brukeren til
+# https://<container-id>:3000. En client_secret med anførselstegn gir
+# `invalid client_secret`, og en client_id gir `client_id is required`.
+#
+# `pnpm dev` og `docker compose` fjerner anførselstegnene, så feilen dukker bare
+# opp i produksjon.
+
 DATABASE_USER=postgres
 DATABASE_PASSWORD=password
 DATABASE_NAME=kontresv2
 
-# For local dev with Docker: use port 5433 to avoid conflict with local Postgres
-DATABASE_URL="postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@127.0.0.1:5433/${DATABASE_NAME}"
+# For local dev with Docker: use port 5433 to avoid conflict with local Postgres.
+# NB: `${...}` utvides av `pnpm dev` og `docker compose`, men ikke av
+# `docker run --env-file` — i produksjon må DATABASE_URL skrives helt ut.
+DATABASE_URL=postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@127.0.0.1:5433/${DATABASE_NAME}
+
+AUTH_SECRET=my-v3ry-s3cret-key
+
+# Hvor appen svarer utad. Må være satt i produksjon: uten den bygger Auth.js
+# absolutte URL-er fra containerens eget vertsnavn, og OAuth-innloggingen sender
+# brukeren til en adresse som ikke finnes. Lokalt kan den utelates.
+AUTH_URL=http://localhost:3000
+
 # Photon — TIHLDEs API og innloggingsleverandør
-PHOTON_API_URL="https://photon.tihlde.org"
+PHOTON_API_URL=https://photon.tihlde.org
 
 # OAuth-klienten denne appen er registrert som i Photon. Opprettes i
 # adminpanelet på tihlde.org (Super admin -> OAuth-klienter), ikke med SQL:
@@ -28,7 +51,6 @@ PHOTON_API_URL="https://photon.tihlde.org"
 # kan roteres i panelet).
 #
 # Redirect URI må være <AUTH_URL>/api/auth/callback/tihlde
-PHOTON_OAUTH_CLIENT_ID=""
-PHOTON_OAUTH_CLIENT_SECRET=""
-
-AUTH_SECRET="my-v3ry-s3cret-key"
+# Scopes: openid, profile, email og offline_access
+PHOTON_OAUTH_CLIENT_ID=
+PHOTON_OAUTH_CLIENT_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ PHOTON_API_URL="https://photon.tihlde.org"
 # OAuth-klienten denne appen er registrert som i Photon. Opprettes i
 # adminpanelet på tihlde.org (Super admin -> OAuth-klienter), ikke med SQL:
 # hemmeligheten lagres hashet, og skrives den rå i basen blir den avvist.
+#
+# Begge verdiene GENERERES av Photon og vises én gang når klienten opprettes.
+# Client-id-en er en tilfeldig streng på 32 tegn — den kan ikke velges, så den
+# er ikke "kontres". Kopier begge ordrett; hemmeligheten vises aldri igjen (men
+# kan roteres i panelet).
+#
 # Redirect URI må være <AUTH_URL>/api/auth/callback/tihlde
 PHOTON_OAUTH_CLIENT_ID=""
 PHOTON_OAUTH_CLIENT_SECRET=""

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ AUTH_SECRET="..."
 AUTH_URL="https://kontres.tihlde.org"
 
 PHOTON_API_URL="https://photon.tihlde.org"
-PHOTON_OAUTH_CLIENT_ID="kontres"
+PHOTON_OAUTH_CLIENT_ID="<generert av Photon>"
 PHOTON_OAUTH_CLIENT_SECRET="tihlde_cs_..."
 ```
 
@@ -60,11 +60,19 @@ klienthemmeligheten lagres hashet, og en rå verdi i basen blir avvist med
 - **Redirect URI:** `<AUTH_URL>/api/auth/callback/tihlde`
 - **Scopes:** `openid`, `profile`, `email` og `offline_access`
 
+Photon genererer både `client_id` og `client_secret`, og viser dem én gang når
+klienten er opprettet. `client_id` er en tilfeldig streng på 32 tegn — den kan
+altså ikke settes til «kontres». Kopier begge ordrett inn i `.env`.
+
 `offline_access` er ikke valgfritt. Uten det utsteder Photon ikke noe
 refresh-token, og innloggingen varer bare én time.
 
 Hemmeligheten inkluderer prefikset `tihlde_cs_`; det er en del av verdien og
 skal med i `PHOTON_OAUTH_CLIENT_SECRET`.
+
+`AUTH_URL` må være satt i miljøet appen faktisk kjører i. Uten den bygger
+Auth.js absolutte URL-er fra containerens eget vertsnavn (`https://<container-id>:3000`),
+og innloggingen sender brukeren til en adresse som ikke finnes.
 ## 🔧 Technologies
 
 - NextJS


### PR DESCRIPTION
Oppfølging til #196. To ting i oppsettdokumentasjonen som var feil eller manglet, funnet under utrullingen.

## `client_id` kan ikke velges

`.env.example` og README ba om `PHOTON_OAUTH_CLIENT_ID="kontres"`. Photon genererer `client_id` som en tilfeldig streng på 32 tegn (`generateRandomString(32, "a-z", "A-Z")`), og adminpanelet sender ikke inn noe ønsket navn — bare `client_name` og redirect-URI-ene.

Verdien «kontres» finnes altså ikke, og authorize svarer:

```
error=invalid_client&error_description=client_id+is+required
```

Den feilmeldingen leser som at man har glemt en parameter, ikke som at klienten ikke finnes. Til sammenligning svarer en klient som *finnes* med `invalid redirect uri` når resten er feil.

## `AUTH_URL` må nå containeren

Uten `AUTH_URL` i miljøet appen faktisk kjører i, bygger Auth.js absolutte URL-er fra containerens eget vertsnavn. I prod sender innloggingen nå brukeren til `https://<container-id>:3000/api/auth/signin`.

Det var ufarlig med passordskjemaet, som aldri forlot appen. OAuth trenger korrekte absolutte URL-er, så det ble synlig først nå.

Bare dokumentasjon — ingen kodeendring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## `.env.example` hadde anførselstegn overalt

`deploy.sh` starter containeren med `docker run --env-file .env`, og Docker tolker ikke anførselstegn — de blir en del av verdien. Verifisert:

```
QUOTED="https://example.org"   →   ["https://example.org"]
BARE=https://example.org       →   [https://example.org]
```

Så `AUTH_URL="https://kontres.tihlde.org"` havner i containeren med anførselstegn og alt. `new URL()` kaster, next-auth svelger feilen, og faller tilbake på containerens eget vertsnavn — som er nøyaktig det prod gjør nå.

Samme felle for de nye variablene, med feilmeldinger som peker feil vei:

| Verdi med anførselstegn | Feil |
|---|---|
| `PHOTON_OAUTH_CLIENT_ID` | `client_id is required` |
| `PHOTON_OAUTH_CLIENT_SECRET` | `invalid client_secret` |

Begge leser som «du skrev inn feil verdi», ikke som «anførselstegnene ble med».

Fila så riktig ut fordi `pnpm dev` og `docker compose` *fjerner* anførselstegnene — feilen finnes bare i produksjon.

Tatt med i samme slengen:

- `AUTH_URL` manglet helt i eksempelet, selv om den må være satt i prod.
- `${...}`-utvidelsen i `DATABASE_URL` gjøres heller ikke av `docker run --env-file`; notert at den må skrives helt ut i prod.
