### PR TITLE
fix(docker): pin pnpm til versjonen package.json krever

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@ WORKDIR /build
 COPY package.json pnpm-lock.yaml ./
 COPY prisma ./prisma/
 
-RUN npm i -g pnpm
+# Samme versjon som `packageManager` i package.json. Uten versjonen henter
+# npm nyeste pnpm, og nyere pnpm prøver da å selv-installere den pinnede
+# versjonen via @pnpm/exe og verifisere den mot pnpm-lock.yaml. Den oppføringen
+# finnes ikke i lockfila, så bygget dør på «Cannot verify the identity of the
+# @pnpm/exe.linux-x64 native binary». Holdes i synk med package.json.
+RUN npm i -g pnpm@10.33.0
 
 RUN pnpm i --frozen-lockfile
 


### PR DESCRIPTION
Docker-bygget har feilet på hver eneste deploy siden 19. mai. Det er derfor #196 og #197 ble merget uten å nå prod.

## Feilen

```
[ERROR] Cannot verify the identity of the @pnpm/exe.linux-x64 native binary:
        it is missing from pnpm-lock.yaml.
ERROR: process "/bin/sh -c pnpm i --frozen-lockfile" did not complete successfully: exit code: 1
```

`Dockerfile` gjør `npm i -g pnpm`, altså nyeste versjon. Nyere pnpm leser `packageManager: "pnpm@10.33.0"` fra `package.json` og prøver å selv-installere akkurat den versjonen via `@pnpm/exe`, og verifiserer den mot lockfila. Den oppføringen finnes ikke der, så installasjonen dør før noe er hentet.

Ingenting i repoet endret seg da det knakk — pnpm gjorde. Det er derfor ingen commit peker på årsaken, og hvorfor deployet gikk fra grønt 19. mai til rødt på hver kjøring etterpå.

## Fiksen

`npm i -g pnpm@10.33.0`, samme versjon som `packageManager` pinner. Da er det ingen versjon å selv-installere. Kommentaren i `Dockerfile` sier at de to må holdes i synk.

## Verifisert lokalt

- `docker build --target deps` feilet på nøyaktig samme steg som CI, med samme melding.
- Etter endringen bygger hele imaget gjennom.
- Imaget starter og svarer 200 på `/login`.
- Med `AUTH_URL` satt sender innloggingen brukeren til riktig sted:

```
https://photon.tihlde.org/api/auth/oauth2/authorize
  ?scope=openid+profile+email+offline_access
  &redirect_uri=http%3A%2F%2Flocalhost%3A3999%2Fapi%2Fauth%2Fcallback%2Ftihlde
  &code_challenge_method=S256...
```

`redirect_uri` bygges fra `AUTH_URL` og ikke fra containerens vertsnavn, scopene er riktige, og PKCE er med. Selve Photon-koden fra #196 er altså i orden — den har bare aldri kommet ut.

## Rekkefølge

Denne bør merges først. Da får neste deploy med seg #196 og #197 også.

🤖 Generated with [Claude Code](https://claude.com/claude-code)